### PR TITLE
作品編集機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -22,6 +22,14 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
   end
 
+  def edit
+    
+  end
+
+  def update
+    
+  end
+
   private
 
   def product_params

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -23,7 +23,7 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    
+    @product = Product.find(params[:id])
   end
 
   def update

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -24,9 +24,7 @@ class ProductsController < ApplicationController
 
   def edit
     @product = Product.find(params[:id])
-    unless @product.user_id == current_user.id
-      redirect_to action: :index
-    end
+    redirect_to action: :index unless @product.user_id == current_user.id
   end
 
   def update

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -24,6 +24,9 @@ class ProductsController < ApplicationController
 
   def edit
     @product = Product.find(params[:id])
+    unless @product.user_id == current_user.id
+      redirect_to action: :index
+    end
   end
 
   def update

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -30,7 +30,12 @@ class ProductsController < ApplicationController
   end
 
   def update
-    
+    @product = Product.find(params[:id])
+    if @product.update(product_params)
+      redirect_to product_path
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="main">
+  <div class="inner">
+    <div class="form__wrapper">
+      <h2 class="page-heading">作品編集</h2>
+      <%= render partial: "form", locals: { product: @product } %>
+    </div>
+  </div>
+</div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -7,7 +7,7 @@
       <%= link_to "by #{@product.user.nickname}", user_path(@product.user.id), class: :prototype__user %>
       <% if user_signed_in? && current_user.id == @product.user_id %>
         <div class="prototype__manage">
-          <%= link_to "編集する",  class: :prototype__btn %>
+          <%= link_to "編集する", edit_product_path, class: :prototype__btn %>
           <%= link_to "削除する",  method: :delete, class: :prototype__btn %>
         </div>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'products#index'
   resources :users, only: [:show]
-  resources :products, only: [:index, :new, :create, :show]
+  resources :products, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
#What
作品編集機能の実装

#Why
作品を編集できるようにするため。

現状、作品投稿ページと作品編集ページを共有している。
保存ボタン、変更ボタン、戻るボタンを独立させる必要あり。
エラーハンドリングの実装は後に行う予定。